### PR TITLE
6022be trigger

### DIFF
--- a/openhantek/src/dockwindows.cpp
+++ b/openhantek/src/dockwindows.cpp
@@ -339,7 +339,7 @@ void TriggerDock::closeEvent(QCloseEvent *event) {
 /// \param mode The trigger mode.
 /// \return Index of mode-value, -1 on error.
 int TriggerDock::setMode(Dso::TriggerMode mode) {
-	if(mode >= Dso::TRIGGERMODE_AUTO && mode <=Dso::TRIGGERMODE_SOFTWARE) {
+	if(mode >= Dso::TRIGGERMODE_AUTO && mode < Dso::TRIGGERMODE_COUNT) {
 		this->modeComboBox->setCurrentIndex(mode);
 		return mode;
 	}

--- a/openhantek/src/hantek/control.cpp
+++ b/openhantek/src/hantek/control.cpp
@@ -860,12 +860,12 @@ namespace Hantek {
 		for(int control = 0; control <= lastControlIndex; ++control)
 			this->controlPending[control] = true;
 
-    // Disable controls not supported by 6022BE
-    if (this->device->getModel() == MODEL_DSO6022BE) {
-      this->controlPending[CONTROLINDEX_SETOFFSET] = false;
-      this->controlPending[CONTROLINDEX_SETRELAYS] = false;
-    }
-		
+		// Disable controls not supported by 6022BE
+		if (this->device->getModel() == MODEL_DSO6022BE) {
+		  this->controlPending[CONTROLINDEX_SETOFFSET] = false;
+		  this->controlPending[CONTROLINDEX_SETRELAYS] = false;
+		}
+
 		// Maximum possible samplerate for a single channel and dividers for record lengths
 		this->specification.bufferDividers.clear();
 		this->specification.samplerate.single.recordLengths.clear();

--- a/openhantek/src/hantek/control.cpp
+++ b/openhantek/src/hantek/control.cpp
@@ -1289,7 +1289,7 @@ namespace Hantek {
 		if(!this->device->isConnected())
 			return Dso::ERROR_CONNECTION;
 		
-		if(mode < Dso::TRIGGERMODE_AUTO || mode > Dso::TRIGGERMODE_SOFTWARE)
+		if(mode < Dso::TRIGGERMODE_AUTO || mode >= Dso::TRIGGERMODE_COUNT)
 			return Dso::ERROR_PARAMETER;
 		
 		this->settings.trigger.mode = mode;


### PR DESCRIPTION
I have a fix for the sw trigger on 6022be.
It makes a very steady image when tested with the 1KHz test signal provided by the scope itself.

Principles are: Based on the trigger position (percentage of screen 0..1) I figure out the number of samples to be listed before and after the trig position at the screen. I then narrow down my search for a trigger-sample in between these two limitations. I can thus afterwards generate a steady drawing.
Example: Samplerate 2MS/s, Timebase 200us leads to 4000samples to be shown.
With trigger set to 30% I know I have to keep 1200 samples before my trigger and 2800 samples after.
Having, say 9240 samples it means I must look for the trig-sampling between sample 1200 and sample 6440. 
If I find my trig sample at say sample 3000 I must make my data start at 1800 (3000-1200).
In my example above I have the range 1200-6440 =  5240 samples to search for a trigger.

With other combinations, like 1MS/s, timebase 1ms I'll need 10000 samples to be shown. Even without your discard of the first 1000 samples this leaves only 240 samples to be searched for a trigger.

If no trigger is found the data will be discarded