### PR TITLE
6022BE: Make samplerate adjust to chosen timebase.

### DIFF
--- a/openhantek/src/dockwindows.cpp
+++ b/openhantek/src/dockwindows.cpp
@@ -339,7 +339,7 @@ void TriggerDock::closeEvent(QCloseEvent *event) {
 /// \param mode The trigger mode.
 /// \return Index of mode-value, -1 on error.
 int TriggerDock::setMode(Dso::TriggerMode mode) {
-	if(mode >= Dso::TRIGGERMODE_AUTO && mode <=Dso::TRIGGERMODE_SOFTWARE) {
+	if(mode >= Dso::TRIGGERMODE_AUTO && mode < Dso::TRIGGERMODE_COUNT) {
 		this->modeComboBox->setCurrentIndex(mode);
 		return mode;
 	}

--- a/openhantek/src/hantek/control.cpp
+++ b/openhantek/src/hantek/control.cpp
@@ -1289,7 +1289,7 @@ namespace Hantek {
 		if(!this->device->isConnected())
 			return Dso::ERROR_CONNECTION;
 		
-		if(mode < Dso::TRIGGERMODE_AUTO || mode > Dso::TRIGGERMODE_SOFTWARE)
+		if(mode < Dso::TRIGGERMODE_AUTO || mode >= Dso::TRIGGERMODE_COUNT)
 			return Dso::ERROR_PARAMETER;
 		
 		this->settings.trigger.mode = mode;


### PR DESCRIPTION

The product of samplerate and timebase (x10) specifies the number of samples
needed to fill up the screen horizontally.
Based on the record length, the system was able to configure a timebase
when the samplerate was changed.

Code exist indicating this should also work in the opposite direction. I.e.
when changing timebase, the samplerate should adjust.

This has been fixed to also work now for 6022BE