### PR TITLE
Probe attenuation selector

### DIFF
--- a/openhantek/src/dataanalyzer.cpp
+++ b/openhantek/src/dataanalyzer.cpp
@@ -341,8 +341,8 @@ void DataAnalyzer::run() {
 				else if(channelData->samples.voltage.sample[position] > maximalVoltage)
 					maximalVoltage = channelData->samples.voltage.sample[position];
 			}
-			
-			channelData->amplitude = maximalVoltage - minimalVoltage;
+			double scale_factor = this->settings->scope.voltage[channel].probe_gain;
+			channelData->amplitude = (maximalVoltage - minimalVoltage) * scale_factor;
 			
 			// Get the frequency from the correlation results
 			double minimumCorrelation = correlation[0];

--- a/openhantek/src/dataanalyzer.cpp
+++ b/openhantek/src/dataanalyzer.cpp
@@ -351,7 +351,6 @@ void DataAnalyzer::run() {
 				else if(channelData->samples.voltage.sample[position] > maximalVoltage)
 					maximalVoltage = channelData->samples.voltage.sample[position];
 			}
-//			double scale_factor = this->settings->scope.voltage[channel].probe_gain;
 			channelData->amplitude = (maximalVoltage - minimalVoltage) ;
 			
 			// Get the frequency from the correlation results

--- a/openhantek/src/dataanalyzer.cpp
+++ b/openhantek/src/dataanalyzer.cpp
@@ -147,7 +147,6 @@ void DataAnalyzer::run() {
 			// Physical channels
 			if(channel < this->settings->scope.physicalChannels) {
 				// Copy the buffer of the oscilloscope into the sample buffer
-                // Update the values from the oscilloscope depending on the attenuation from the probe
                 unsigned int initial_position = 0;
 				if(this->waitingDataAppend) {
                     initial_position = channelData->samples.voltage.sample.size();
@@ -157,9 +156,9 @@ void DataAnalyzer::run() {
                 }
 				else
                     channelData->samples.voltage.sample = this->waitingData->at(channel);
-
+                // Update the values from the oscilloscope depending on the attenuation from the probe
                 unsigned long sampleCount = channelData->samples.voltage.sample.size();
-                for (unsigned int position = 0 + initial_position; position < sampleCount; ++position) {
+                for (unsigned int position = 0 + initial_position; position < sampleCount; position++) {
                     channelData->samples.voltage.sample[position] *= this->settings->scope.voltage[channel].probe_gain;
                 }
 			}

--- a/openhantek/src/dataanalyzer.cpp
+++ b/openhantek/src/dataanalyzer.cpp
@@ -147,10 +147,21 @@ void DataAnalyzer::run() {
 			// Physical channels
 			if(channel < this->settings->scope.physicalChannels) {
 				// Copy the buffer of the oscilloscope into the sample buffer
-				if(this->waitingDataAppend)
-					channelData->samples.voltage.sample.insert(channelData->samples.voltage.sample.end(), this->waitingData->at(channel).begin(), this->waitingData->at(channel).end());
+                // Update the values from the oscilloscope depending on the attenuation from the probe
+                unsigned int initial_position = 0;
+				if(this->waitingDataAppend) {
+                    initial_position = channelData->samples.voltage.sample.size();
+                    channelData->samples.voltage.sample.insert(channelData->samples.voltage.sample.end(),
+                                                               this->waitingData->at(channel).begin(),
+                                                               this->waitingData->at(channel).end());
+                }
 				else
-					channelData->samples.voltage.sample = this->waitingData->at(channel);
+                    channelData->samples.voltage.sample = this->waitingData->at(channel);
+
+                unsigned long sampleCount = channelData->samples.voltage.sample.size();
+                for (unsigned int position = 0 + initial_position; position < sampleCount; ++position) {
+                    channelData->samples.voltage.sample[position] *= this->settings->scope.voltage[channel].probe_gain;
+                }
 			}
 			// Math channel
 			else {
@@ -341,8 +352,8 @@ void DataAnalyzer::run() {
 				else if(channelData->samples.voltage.sample[position] > maximalVoltage)
 					maximalVoltage = channelData->samples.voltage.sample[position];
 			}
-			double scale_factor = this->settings->scope.voltage[channel].probe_gain;
-			channelData->amplitude = (maximalVoltage - minimalVoltage) * scale_factor;
+//			double scale_factor = this->settings->scope.voltage[channel].probe_gain;
+			channelData->amplitude = (maximalVoltage - minimalVoltage) ;
 			
 			// Get the frequency from the correlation results
 			double minimumCorrelation = correlation[0];

--- a/openhantek/src/dockwindows.cpp
+++ b/openhantek/src/dockwindows.cpp
@@ -766,6 +766,7 @@ void VoltageDock::probeGainSelected(int index) {
 			break;
 	if(channel < this->settings->scope.voltage.count()){
 		this->settings->scope.voltage[channel].probe_gain = this->probeGainSteps.at(index);
+        emit probeGainChanged(channel, this->settings->scope.voltage[channel].probe_gain);
 	}
 
 };

--- a/openhantek/src/dockwindows.cpp
+++ b/openhantek/src/dockwindows.cpp
@@ -560,16 +560,19 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags
 	// Initialize elements
 	for(int channel = 0; channel < this->settings->scope.voltage.count(); ++channel) {
 		this->miscComboBox.append(new QComboBox());
-		if(channel < (int) this->settings->scope.physicalChannels)
-			this->miscComboBox[channel]->addItems(this->couplingStrings);
+		if(channel < (int) this->settings->scope.physicalChannels) {
+            this->miscComboBox[channel]->addItems(this->couplingStrings);
+            this->probeGainCombobox.append(new QComboBox());
+            this->probeGainCombobox[channel]->addItems(this->probeGainStrings);
+        }
 		else
 			this->miscComboBox[channel]->addItems(this->modeStrings);
 		
 		this->gainComboBox.append(new QComboBox());
 		this->gainComboBox[channel]->addItems(this->gainStrings);
+        if(channel < (int) this->settings->scope.physicalChannels) {
 
-        this->probeGainCombobox.append(new QComboBox());
-        this->probeGainCombobox[channel]->addItems(this->probeGainStrings);
+        }
 
 		this->usedCheckBox.append(new QCheckBox(this->settings->scope.voltage[channel].name));
 
@@ -583,7 +586,8 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags
 		this->dockLayout->addWidget(this->usedCheckBox[channel], channel * 3, 0);
 		this->dockLayout->addWidget(this->gainComboBox[channel], channel * 3, 1);
 		this->dockLayout->addWidget(this->miscComboBox[channel], channel * 3 + 1, 1);
-		this->dockLayout->addWidget(this->probeGainCombobox[channel], channel * 3 +2, 1);
+        if(channel < (int) this->settings->scope.physicalChannels)
+		    this->dockLayout->addWidget(this->probeGainCombobox[channel], channel * 3 +2, 1);
 	}
 
 	this->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
@@ -597,17 +601,19 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags
 		connect(this->gainComboBox[channel], SIGNAL(currentIndexChanged(int)), this, SLOT(gainSelected(int)));
 		connect(this->miscComboBox[channel], SIGNAL(currentIndexChanged(int)), this, SLOT(miscSelected(int)));
 		connect(this->usedCheckBox[channel], SIGNAL(toggled(bool)), this, SLOT(usedSwitched(bool)));
-		connect(this->probeGainCombobox[channel], SIGNAL(currentIndexChanged(int)), this, SLOT(probeGainSelected(int)));
+        if(channel < (int) this->settings->scope.physicalChannels)
+		    connect(this->probeGainCombobox[channel], SIGNAL(currentIndexChanged(int)), this, SLOT(probeGainSelected(int)));
 	}
 	
 	// Set values
 	for(int channel = 0; channel < this->settings->scope.voltage.count(); ++channel) {
-		if(channel < (int) this->settings->scope.physicalChannels)
-			this->setCoupling(channel, (Dso::Coupling) this->settings->scope.voltage[channel].misc);
-		else
+		if(channel < (int) this->settings->scope.physicalChannels) {
+            this->setCoupling(channel, (Dso::Coupling) this->settings->scope.voltage[channel].misc);
+            this->setProbeGain(channel, this->settings->scope.voltage[channel].probe_gain);
+        }
+        else
 			this->setMode((Dso::MathMode) this->settings->scope.voltage[channel].misc);
 		this->setGain(channel, this->settings->scope.voltage[channel].gain);
-        this->setProbeGain(channel, this->settings->scope.voltage[channel].probe_gain);
 		this->setUsed(channel, this->settings->scope.voltage[channel].used);
 	}
 }

--- a/openhantek/src/dockwindows.cpp
+++ b/openhantek/src/dockwindows.cpp
@@ -659,6 +659,11 @@ int VoltageDock::setGain(int channel, double gain) {
 	return index;
 }
 
+
+/// \brief Sets the probe gain for a channel.
+/// \param channel The channel, whose probe gain should be set.
+/// \param probeGain The probe gain in volts.
+/// \return Index of probeGain-value, -1 on error.
 int VoltageDock::setProbeGain(int channel, double probeGain) {
     if(channel < 0 || channel >= this->settings->scope.voltage.count())
         return -1;

--- a/openhantek/src/dockwindows.cpp
+++ b/openhantek/src/dockwindows.cpp
@@ -552,7 +552,7 @@ VoltageDock::VoltageDock(DsoSettings *settings, QWidget *parent, Qt::WindowFlags
 	for(QList<double>::iterator gain = this->gainSteps.begin(); gain != this->gainSteps.end(); ++gain)
 		this->gainStrings << Helper::valueToString(*gain, Helper::UNIT_VOLTS, 0);
 
-    this->probeGainSteps <<  1e0 <<  2e0 <<  5e0 << 10e0;
+    this->probeGainSteps <<  1e0 <<  2e0 <<  5e0 << 10e0; ///< Probe gain as multiplier
     for(QList<double>::iterator probe_gain = this->probeGainSteps.begin(); probe_gain != this->probeGainSteps.end(); ++probe_gain)
         this->probeGainStrings << Helper::valueToString(*probe_gain, Helper::UNIT_TIMES, 0);
 
@@ -744,6 +744,8 @@ void VoltageDock::usedSwitched(bool checked) {
 	}
 }
 
+/// \brief Calld when the probe combo box changes it's value.
+/// \param index The index of the combo box item.
 void VoltageDock::probeGainSelected(int index) {
 	int channel;
 

--- a/openhantek/src/dockwindows.h
+++ b/openhantek/src/dockwindows.h
@@ -194,6 +194,7 @@ class VoltageDock : public QDockWidget {
 	signals:
 		void couplingChanged(unsigned int channel, Dso::Coupling coupling); ///< A coupling has been selected
 		void gainChanged(unsigned int channel, double gain); ///< A gain has been selected
+		void probeGainChanged(unsigned int channel, int probeGain); ///< A probe gain has been selected
 		void modeChanged(Dso::MathMode mode); ///< The mode for the math channels has been changed
 		void usedChanged(unsigned int channel, bool used); ///< A channel has been enabled/disabled
 		void probeGainChanged(unsigned int channel, double gain);

--- a/openhantek/src/dockwindows.h
+++ b/openhantek/src/dockwindows.h
@@ -196,6 +196,7 @@ class VoltageDock : public QDockWidget {
 		void gainChanged(unsigned int channel, double gain); ///< A gain has been selected
 		void modeChanged(Dso::MathMode mode); ///< The mode for the math channels has been changed
 		void usedChanged(unsigned int channel, bool used); ///< A channel has been enabled/disabled
+		void probeGainChanged(unsigned int channel, double gain);
 };
 
 

--- a/openhantek/src/dockwindows.h
+++ b/openhantek/src/dockwindows.h
@@ -162,6 +162,7 @@ class VoltageDock : public QDockWidget {
 		
 		int setCoupling(int channel, Dso::Coupling coupling);
 		int setGain(int channel, double gain);
+        int setProbeGain(int channel, double probeGain);
 		int setMode(Dso::MathMode mode);
 		int setUsed(int channel, bool used);
 	
@@ -173,18 +174,22 @@ class VoltageDock : public QDockWidget {
 		QList<QCheckBox *> usedCheckBox; ///< Enable/disable a specific channel
 		QList<QComboBox *> gainComboBox; ///< Select the vertical gain for the channels
 		QList<QComboBox *> miscComboBox; ///< Select coupling for real and mode for math channels
+		QList<QComboBox *> probeGainCombobox; ///< Select the voltage division of the probe
 		
 		DsoSettings *settings; ///< The settings provided by the parent class
 		
 		QStringList couplingStrings; ///< The strings for the couplings
 		QStringList modeStrings; ///< The strings for the math mode
 		QList<double> gainSteps; ///< The selectable gain steps
+        QList<double> probeGainSteps;
+        QStringList probeGainStrings;
 		QStringList gainStrings; ///< String representations for the gain steps
 	
 	protected slots:
 		void gainSelected(int index);
 		void miscSelected(int index);
 		void usedSwitched(bool checked);
+		void probeGainSelected(int index);
 	
 	signals:
 		void couplingChanged(unsigned int channel, Dso::Coupling coupling); ///< A coupling has been selected

--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -421,6 +421,16 @@ void DsoWidget::updateVoltageGain(unsigned int channel) {
 	this->updateVoltageDetails(channel);
 }
 
+/// \brief Handles probeGainChanged signal from the voltage dock.
+/// \param channel The channel whose probe gain was changed.
+void DsoWidget::updateProbeGain(unsigned int channel) {
+    if(channel >= (unsigned int) this->settings->scope.voltage.count())
+        return;
+
+    this->updateVoltageDetails(channel);
+
+}
+
 /// \brief Handles usedChanged signal from the voltage dock.
 /// \param channel The channel whose used-state was changed.
 /// \param used The new used-state for the channel.

--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -493,7 +493,8 @@ void DsoWidget::dataAnalyzed() {
 	for(int channel = 0; channel < this->settings->scope.voltage.count(); ++channel) {
 		if(this->settings->scope.voltage[channel].used && this->dataAnalyzer->data(channel)) {
 
-			double scale_factor = this->settings->scope.voltage[channel].probe_gain;
+//			double scale_factor = this->settings->scope.voltage[channel].probe_gain;
+			double scale_factor = 1;
 			// Amplitude string representation (4 significant digits)
 			this->measurementAmplitudeLabel[channel]->setText(Helper::valueToString(this->dataAnalyzer->data(channel)->amplitude * scale_factor, Helper::UNIT_VOLTS, 4));
 			// Frequency string representation (5 significant digits)

--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -535,11 +535,11 @@ void DsoWidget::updateTriggerPosition(int index, double value) {
 /// \param channel The index of the slider.
 /// \param value The new trigger level.
 void DsoWidget::updateTriggerLevel(int channel, double value) {
-	this->settings->scope.voltage[channel].trigger = value;
-	
+	this->settings->scope.voltage[channel].trigger = value ;
+
 	this->updateTriggerDetails();
 	
-	emit triggerLevelChanged(channel, value);
+	emit triggerLevelChanged(channel, value );
 }
 
 /// \brief Handles valueChanged signal from the marker slider.

--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -485,16 +485,17 @@ void DsoWidget::updateZoom(bool enabled) {
 		this->updateMarkerDetails();
 	else
 		this->markerInfoLabel->setText(tr("Marker 1/2"));
-	
 	this->repaint();
 }
 
 /// \brief Prints analyzed data.
 void DsoWidget::dataAnalyzed() {
 	for(int channel = 0; channel < this->settings->scope.voltage.count(); ++channel) {
-		if(this->settings->scope.voltage[channel].used && this->dataAnalyzer->data(channel)) {			
+		if(this->settings->scope.voltage[channel].used && this->dataAnalyzer->data(channel)) {
+
+			double scale_factor = this->settings->scope.voltage[channel].probe_gain;
 			// Amplitude string representation (4 significant digits)
-			this->measurementAmplitudeLabel[channel]->setText(Helper::valueToString(this->dataAnalyzer->data(channel)->amplitude, Helper::UNIT_VOLTS, 4));
+			this->measurementAmplitudeLabel[channel]->setText(Helper::valueToString(this->dataAnalyzer->data(channel)->amplitude * scale_factor, Helper::UNIT_VOLTS, 4));
 			// Frequency string representation (5 significant digits)
 			this->measurementFrequencyLabel[channel]->setText(Helper::valueToString(this->dataAnalyzer->data(channel)->frequency, Helper::UNIT_HERTZ, 5));
 		}

--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -493,10 +493,8 @@ void DsoWidget::dataAnalyzed() {
 	for(int channel = 0; channel < this->settings->scope.voltage.count(); ++channel) {
 		if(this->settings->scope.voltage[channel].used && this->dataAnalyzer->data(channel)) {
 
-//			double scale_factor = this->settings->scope.voltage[channel].probe_gain;
-			double scale_factor = 1;
 			// Amplitude string representation (4 significant digits)
-			this->measurementAmplitudeLabel[channel]->setText(Helper::valueToString(this->dataAnalyzer->data(channel)->amplitude * scale_factor, Helper::UNIT_VOLTS, 4));
+			this->measurementAmplitudeLabel[channel]->setText(Helper::valueToString(this->dataAnalyzer->data(channel)->amplitude, Helper::UNIT_VOLTS, 4));
 			// Frequency string representation (5 significant digits)
 			this->measurementFrequencyLabel[channel]->setText(Helper::valueToString(this->dataAnalyzer->data(channel)->frequency, Helper::UNIT_HERTZ, 5));
 		}

--- a/openhantek/src/dsowidget.h
+++ b/openhantek/src/dsowidget.h
@@ -114,8 +114,10 @@ class DsoWidget : public QWidget {
 		void updateMathMode();
 		void updateVoltageGain(unsigned int channel);
 		void updateVoltageUsed(unsigned int channel, bool used);
-		
-		// Menus
+		void updateProbeGain(unsigned int channel);
+
+
+	// Menus
 		void updateRecordLength(unsigned long size);
 		
 		// Export

--- a/openhantek/src/glgenerator.cpp
+++ b/openhantek/src/glgenerator.cpp
@@ -209,7 +209,7 @@ void GlGenerator::generateGraphs() {
 
 							for(unsigned int position = 0; position < sampleCount; ++position) {
 								*(glIterator++) = position * horizontalFactor - DIVS_TIME / 2;
-								*(glIterator++) = *(dataIterator++) / gain  + offset;
+								*(glIterator++) = *(dataIterator++) / gain + offset;
 							}
 						}
 						else {

--- a/openhantek/src/glgenerator.cpp
+++ b/openhantek/src/glgenerator.cpp
@@ -204,12 +204,13 @@ void GlGenerator::generateGraphs() {
 							std::vector<double>::const_iterator dataIterator = this->dataAnalyzer->data(channel)->samples.voltage.sample.begin();
 							const double gain = this->settings->scope.voltage[channel].gain;
 							const double offset = this->settings->scope.voltage[channel].offset;
+							const double probe_gain = this->settings->scope.voltage[channel].probe_gain;
 							
 							std::advance(dataIterator, swTriggerStart-preTrigSamples);
 
 							for(unsigned int position = 0; position < sampleCount; ++position) {
 								*(glIterator++) = position * horizontalFactor - DIVS_TIME / 2;
-								*(glIterator++) = *(dataIterator++) / gain + offset;
+								*(glIterator++) = probe_gain * (*(dataIterator++) / gain ) + offset;
 							}
 						}
 						else {
@@ -258,11 +259,12 @@ void GlGenerator::generateGraphs() {
 					std::vector<double>::const_iterator yIterator = this->dataAnalyzer->data(yChannel)->samples.voltage.sample.begin();
 					const double xGain = this->settings->scope.voltage[xChannel].gain;
 					const double yGain = this->settings->scope.voltage[yChannel].gain;
+					const double probeGain = this->settings->scope.voltage[xChannel].probe_gain;
 					const double xOffset = this->settings->scope.voltage[xChannel].offset;
 					const double yOffset = this->settings->scope.voltage[yChannel].offset;
 					
 					for(unsigned int position = 0; position < sampleCount; ++position) {
-						*(glIterator++) = *(xIterator++) / xGain + xOffset;
+						*(glIterator++) = (*(xIterator++) / xGain)  * probeGain + xOffset;
 						*(glIterator++) = *(yIterator++) / yGain + yOffset;
 					}
 				}

--- a/openhantek/src/glgenerator.cpp
+++ b/openhantek/src/glgenerator.cpp
@@ -204,14 +204,12 @@ void GlGenerator::generateGraphs() {
 							std::vector<double>::const_iterator dataIterator = this->dataAnalyzer->data(channel)->samples.voltage.sample.begin();
 							const double gain = this->settings->scope.voltage[channel].gain;
 							const double offset = this->settings->scope.voltage[channel].offset;
-//							const double probe_gain = this->settings->scope.voltage[channel].probe_gain;
-							const double probe_gain = 1;
 
 							std::advance(dataIterator, swTriggerStart-preTrigSamples);
 
 							for(unsigned int position = 0; position < sampleCount; ++position) {
 								*(glIterator++) = position * horizontalFactor - DIVS_TIME / 2;
-								*(glIterator++) = probe_gain * (*(dataIterator++) / gain ) + offset;
+								*(glIterator++) = *(dataIterator++) / gain  + offset;
 							}
 						}
 						else {
@@ -260,13 +258,11 @@ void GlGenerator::generateGraphs() {
 					std::vector<double>::const_iterator yIterator = this->dataAnalyzer->data(yChannel)->samples.voltage.sample.begin();
 					const double xGain = this->settings->scope.voltage[xChannel].gain;
 					const double yGain = this->settings->scope.voltage[yChannel].gain;
-//					const double probeGain = this->settings->scope.voltage[xChannel].probe_gain;
-					const double probeGain = 1;
 					const double xOffset = this->settings->scope.voltage[xChannel].offset;
 					const double yOffset = this->settings->scope.voltage[yChannel].offset;
 					
 					for(unsigned int position = 0; position < sampleCount; ++position) {
-						*(glIterator++) = (*(xIterator++) / xGain)  * probeGain + xOffset;
+						*(glIterator++) = *(xIterator++) / xGain + xOffset;
 						*(glIterator++) = *(yIterator++) / yGain + yOffset;
 					}
 				}

--- a/openhantek/src/glgenerator.cpp
+++ b/openhantek/src/glgenerator.cpp
@@ -204,8 +204,9 @@ void GlGenerator::generateGraphs() {
 							std::vector<double>::const_iterator dataIterator = this->dataAnalyzer->data(channel)->samples.voltage.sample.begin();
 							const double gain = this->settings->scope.voltage[channel].gain;
 							const double offset = this->settings->scope.voltage[channel].offset;
-							const double probe_gain = this->settings->scope.voltage[channel].probe_gain;
-							
+//							const double probe_gain = this->settings->scope.voltage[channel].probe_gain;
+							const double probe_gain = 1;
+
 							std::advance(dataIterator, swTriggerStart-preTrigSamples);
 
 							for(unsigned int position = 0; position < sampleCount; ++position) {
@@ -259,7 +260,8 @@ void GlGenerator::generateGraphs() {
 					std::vector<double>::const_iterator yIterator = this->dataAnalyzer->data(yChannel)->samples.voltage.sample.begin();
 					const double xGain = this->settings->scope.voltage[xChannel].gain;
 					const double yGain = this->settings->scope.voltage[yChannel].gain;
-					const double probeGain = this->settings->scope.voltage[xChannel].probe_gain;
+//					const double probeGain = this->settings->scope.voltage[xChannel].probe_gain;
+					const double probeGain = 1;
 					const double xOffset = this->settings->scope.voltage[xChannel].offset;
 					const double yOffset = this->settings->scope.voltage[yChannel].offset;
 					

--- a/openhantek/src/helper.cpp
+++ b/openhantek/src/helper.cpp
@@ -135,7 +135,7 @@ namespace Helper {
 					return QApplication::tr("%L1 GS").arg(value / 1e9, 0, format, (precision <= 0) ? precision : qMax(0, precision + 8 - logarithm));
 			}
 			case UNIT_TIMES:{
-				return QApplication::tr("%L1 X").arg(value);
+				return QApplication::tr("X%L1").arg(value);
 			}
 			default:
 				return QString();

--- a/openhantek/src/helper.cpp
+++ b/openhantek/src/helper.cpp
@@ -134,6 +134,9 @@ namespace Helper {
 				else
 					return QApplication::tr("%L1 GS").arg(value / 1e9, 0, format, (precision <= 0) ? precision : qMax(0, precision + 8 - logarithm));
 			}
+			case UNIT_TIMES:{
+				return QApplication::tr("%L1 X").arg(value);
+			}
 			default:
 				return QString();
 		}

--- a/openhantek/src/helper.h
+++ b/openhantek/src/helper.h
@@ -40,7 +40,8 @@ namespace Helper {
 	enum Unit {
 		UNIT_VOLTS, UNIT_DECIBEL,
 		UNIT_SECONDS, UNIT_HERTZ,
-		UNIT_SAMPLES, UNIT_COUNT
+		UNIT_SAMPLES, UNIT_COUNT,
+		UNIT_TIMES
 	};
 	
 	QString libUsbErrorString(int error);

--- a/openhantek/src/openhantek.cpp
+++ b/openhantek/src/openhantek.cpp
@@ -302,9 +302,7 @@ void OpenHantekMainWindow::connectSignals() {
 	connect(this->voltageDock, SIGNAL(gainChanged(unsigned int, double)), this, SLOT(updateVoltageGain(unsigned int)));
 	connect(this->voltageDock, SIGNAL(gainChanged(unsigned int, double)), this->dsoWidget, SLOT(updateVoltageGain(unsigned int)));
     connect(this->voltageDock, SIGNAL(probeGainChanged(unsigned int, double)), this->dsoWidget, SLOT(updateProbeGain(unsigned int)));
-
-
-    connect(this->dsoWidget, SIGNAL(offsetChanged(unsigned int, double)), this, SLOT(updateOffset(unsigned int)));
+	connect(this->dsoWidget, SIGNAL(offsetChanged(unsigned int, double)), this, SLOT(updateOffset(unsigned int)));
 	
 	connect(this->spectrumDock, SIGNAL(usedChanged(unsigned int, bool)), this, SLOT(updateUsed(unsigned int)));
 	connect(this->spectrumDock, SIGNAL(usedChanged(unsigned int, bool)), this->dsoWidget, SLOT(updateSpectrumUsed(unsigned int, bool)));

--- a/openhantek/src/openhantek.cpp
+++ b/openhantek/src/openhantek.cpp
@@ -301,7 +301,10 @@ void OpenHantekMainWindow::connectSignals() {
 	connect(this->voltageDock, SIGNAL(modeChanged(Dso::MathMode)), this->dsoWidget, SLOT(updateMathMode()));
 	connect(this->voltageDock, SIGNAL(gainChanged(unsigned int, double)), this, SLOT(updateVoltageGain(unsigned int)));
 	connect(this->voltageDock, SIGNAL(gainChanged(unsigned int, double)), this->dsoWidget, SLOT(updateVoltageGain(unsigned int)));
-	connect(this->dsoWidget, SIGNAL(offsetChanged(unsigned int, double)), this, SLOT(updateOffset(unsigned int)));
+    connect(this->voltageDock, SIGNAL(probeGainChanged(unsigned int, double)), this->dsoWidget, SLOT(updateProbeGain(unsigned int)));
+
+
+    connect(this->dsoWidget, SIGNAL(offsetChanged(unsigned int, double)), this, SLOT(updateOffset(unsigned int)));
 	
 	connect(this->spectrumDock, SIGNAL(usedChanged(unsigned int, bool)), this, SLOT(updateUsed(unsigned int)));
 	connect(this->spectrumDock, SIGNAL(usedChanged(unsigned int, bool)), this->dsoWidget, SLOT(updateSpectrumUsed(unsigned int, bool)));

--- a/openhantek/src/settings.cpp
+++ b/openhantek/src/settings.cpp
@@ -142,6 +142,7 @@ void DsoSettings::setChannelCount(unsigned int channels) {
 		if(this->scope.voltage.count() <= channel + 1) {
 			DsoSettingsScopeVoltage newVoltage;
 			newVoltage.gain = 1.0;
+			newVoltage.probe_gain = 1.0;
 			newVoltage.misc = Dso::COUPLING_DC;
 			newVoltage.name = QApplication::tr("CH%1").arg(channel + 1);
 			newVoltage.offset = 0.0;
@@ -176,6 +177,7 @@ void DsoSettings::setChannelCount(unsigned int channels) {
 	if(this->scope.voltage.count() <= (int) channels) {
 		DsoSettingsScopeVoltage newVoltage;
 		newVoltage.gain = 1.0;
+		newVoltage.probe_gain = 1.0;
 		newVoltage.misc = Dso::MATHMODE_1ADD2;
 		newVoltage.name = QApplication::tr("MATH");
 		newVoltage.offset = 0.0;
@@ -315,6 +317,8 @@ int DsoSettings::load(const QString &fileName) {
 		settingsLoader->beginGroup(QString("vertical%1").arg(channel));
 		if(settingsLoader->contains("gain"))
 			this->scope.voltage[channel].gain = settingsLoader->value("gain").toDouble();
+		if(settingsLoader->contains("probeGain"))
+			this->scope.voltage[channel].probe_gain = settingsLoader->value("probeGain").toDouble();
 		if(settingsLoader->contains("misc"))
 			this->scope.voltage[channel].misc = settingsLoader->value("misc").toInt();
 		if(settingsLoader->contains("offset"))
@@ -481,6 +485,7 @@ int DsoSettings::save(const QString &fileName) {
 	for(int channel = 0; channel < this->scope.voltage.count(); ++channel) {
 		settingsSaver->beginGroup(QString("vertical%1").arg(channel));
 		settingsSaver->setValue("gain", this->scope.voltage[channel].gain);
+		settingsSaver->setValue("probeGain", this->scope.voltage[channel].probe_gain);
 		settingsSaver->setValue("misc", this->scope.voltage[channel].misc);
 		settingsSaver->setValue("offset", this->scope.voltage[channel].offset);
 		settingsSaver->setValue("trigger", this->scope.voltage[channel].trigger);

--- a/openhantek/src/settings.h
+++ b/openhantek/src/settings.h
@@ -127,7 +127,6 @@ struct DsoSettingsScopeSpectrum {
 struct DsoSettingsScopeVoltage {
 	double gain; ///< The vertical resolution in V/div
 	int misc; ///< Different enums, coupling for real- and mode for math-channels
-	bool x10;
     double probe_gain;
 	QString name; ///< Name of this channel
 	double offset; ///< Vertical offset in divs

--- a/openhantek/src/settings.h
+++ b/openhantek/src/settings.h
@@ -127,6 +127,8 @@ struct DsoSettingsScopeSpectrum {
 struct DsoSettingsScopeVoltage {
 	double gain; ///< The vertical resolution in V/div
 	int misc; ///< Different enums, coupling for real- and mode for math-channels
+	bool x10;
+    double probe_gain;
 	QString name; ///< Name of this channel
 	double offset; ///< Vertical offset in divs
 	double trigger; ///< Trigger level in V


### PR DESCRIPTION
I've added a selector for probe attenuation.
It works by scaling the data acquired from the scope by a factor dependent from the selected attenuation:
ie. x10 attenuation the acquired data will be multiplied by 10.

For now the possible gain are 1,2,5,10 but i can add more if needed. 
